### PR TITLE
Using more of Go's defaults

### DIFF
--- a/tlsdefaults.go
+++ b/tlsdefaults.go
@@ -5,26 +5,11 @@ import (
 	"crypto/tls"
 )
 
-var (
-	// The ECDHE cipher suites are preferred for performance and forward
-	// secrecy.  See https://community.qualys.com/blogs/securitylabs/2013/06/25/ssl-labs-deploying-forward-secrecy.
-	preferredCipherSuites = []uint16{
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-	}
-)
-
-// Server provides a tls.Config with sensible defaults for server use.
+// Server provides a tls.Config with sensible defaults for server use. At this
+// point, it mostly trusts the defaults from Go (assumes Go version 1.5 or
+// or newer).
 func Server() *tls.Config {
 	return &tls.Config{
-		MinVersion:               tls.VersionTLS10, // mitigate against POODLE
 		PreferServerCipherSuites: true,
-		CipherSuites:             preferredCipherSuites, // maximize likelihood of perfect forward secrecy
 	}
 }


### PR DESCRIPTION
As @fffw and @myleshorton suggested, defaulting to Go's defaults makes this somewhat less fingerprintable.  With the exception of preferring the server's cipher suites (which I think is a good idea), this now uses the same defaults as Go.  I tested with Qualys labs against binaries built both with Go 1.5 and Go 1.6, and both get an equivalent A grade from Qualys labs.